### PR TITLE
Initail md for project rubrics

### DIFF
--- a/docs/Project1GradingRubric.md
+++ b/docs/Project1GradingRubric.md
@@ -1,0 +1,49 @@
+
+<br clear=all>
+
+|What | Notes|score 0..4<br>(0=no, 2=ok, 4=wow!)| Evidence |
+|-----|------|------|
+|Misc | Group members attended tutorial sessions|4| |
+|Distrbuted dev model: | decisions made by unanmyous vote}|4| |
+|| group meetings had a round robin speaking order|4| |
+|| group meetings had a moderator that managed the round robin|3| |
+|| group meeting moderator rotated among  the group|4| |
+|| code conforms to some packaging standard|2| |
+|| code has can be downloaded from some standard package manager|4| |
+| |workload is spread over the whole team (one team member is often Xtimes more productive than the others... but nevertheless, here is a track record that everyone is contributing a lot)|4| |
+|| Number of commits|2| |
+|| Number of commits: by different people|3| |
+|| License: exists|4| |
+|| DOI badge: exists |4| |
+||Docs: doco generated , format not ugly |3| |
+||Docs: what: point descriptions of each class/function (in isolation) |0| |
+||Docs: how: for common use cases X,Y,Z mini-tutorials showing worked examples on how to do X,Y,Z|0| |
+||Docs: why: docs tell a story, motivate the whole thing, deliver a punchline that makes you want to rush out and use the thing|0| |
+||Docs: 30 seconds video, posted to YouTube. That convinces people why they want to work on your code.|0| |
+|| (hard) code conforms to some known patterns |2| |
+|Tools Matter| Use of version control tools|4| |
+|| Extensive use of version control tools |4| |
+|| Repo has an up-to-date requirements.txt file|0| |
+|| Repo does not have "ignore" files.|0| |
+|| Use of  style checkers |0| |
+|| Use of code  formatters. |4| |
+|| Extensive Use of code  formatters. |4| |
+|| Use of syntax checkers. |4| |
+|| Extensive use of syntax checkers. |4| |
+|| Use of code coverage |0| |
+|| Extensive use of code coverage |0| |
+|| test cases exist|0| |
+|| test cases are routinely executed|0| |
+| consensus-oriented model| the files CONTRIBUTING.md and CODEOFCONDUCT.md has have multiple edits by multiple people|0| |
+| | the files CONTRIBUTING.md lists coding standards and lots of tips on how to extend the system without screwing things up|0| |
+| | multiple people contribute to discussions|4| |
+|| issues are discussed before they are closed|4| |
+|| Chat channel: exists|4| |
+|| Chat channel: is active |4| |
+|| test cases:.a large proportion of the issues related to handling failing cases.|2| |
+| zero internal boundaries | evidence that the whole team is using the same tools: everyone can get to all tools and files|4| |
+| | evidence that the whole team is using the same tools (e.g. config files in the repo, updated by lots of different people)|4| |
+| | evidence that the whole team is using the same tools (e.g. tutor can ask anyone to share screen, they demonstrate the system running on their computer)|4| |
+| | evidence that the members of the team are working across multiple places in the code base|4| |
+| low-regressions rule | (hard to judge) features released are not subsequently removed|2| |
+|short release cycles | (hard to see in short projects) project members are committing often enough so that everyone can get your work|4| |


### PR DESCRIPTION
Added rubrics for project. 
 //Todo -  
 1. I have kept column 1 as the Linux kernel principle mapping. Not sure if we can do this else we will have to remove as docs say only 3 columns
 2. The Evidence column is empty and we have to  improve upon the rubrics where score is 0